### PR TITLE
Set .data segment copy address source to flash address

### DIFF
--- a/configs/hdk/scripts/stm32l476xx.ld
+++ b/configs/hdk/scripts/stm32l476xx.ld
@@ -105,9 +105,9 @@ SECTIONS {
      *  DATA
      */
     . = ALIGN(4);
+    _sidata = LOADADDR(.data);
     .data : {
         _sdata = ABSOLUTE(.);
-        _sidata = _sdata;
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
         _edata = ABSOLUTE(.);


### PR DESCRIPTION
_sidata pointed to the .data representation in RAM rather than FLASH.
This caused DataCopyInit to copy from RAM to RAM leaving static data
uninitialized. Moving the _sidata value in the ldconfig script to
point to the FLASH region for .data, provides the correct source for
the copy.

Signed-off-by: Jim Wylder <jwylder@motorola.com>