### PR TITLE
Flash Bank 2 Pages start at 256 regardless of memory size

### DIFF
--- a/STM32Cube_FW_L4_V1.0.0/Drivers/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_flash.h
+++ b/STM32Cube_FW_L4_V1.0.0/Drivers/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_flash.h
@@ -709,6 +709,8 @@ uint32_t HAL_FLASH_GetError(void);
 
 #define FLASH_BANK_SIZE                    (FLASH_SIZE >> 1)
 
+#define FLASH_BANK_2_PAGE_BASE             ((uint32_t)256)
+
 #define FLASH_PAGE_SIZE                    ((uint32_t)0x800)
 
 #define FLASH_TIMEOUT_VALUE                ((uint32_t)50000)/* 50 s */

--- a/src/stm32l4xx_flash.c
+++ b/src/stm32l4xx_flash.c
@@ -249,7 +249,8 @@ static uint32_t GetPage(uint32_t Addr)
   else
   {
     /* Bank 2 */
-    page = (Addr - (FLASH_BASE + FLASH_BANK_SIZE)) / FLASH_PAGE_SIZE;
+    page = (Addr - (FLASH_BASE + FLASH_BANK_SIZE)) / FLASH_PAGE_SIZE +
+            FLASH_BANK_2_PAGE_BASE;
   }
 
   return page;


### PR DESCRIPTION
GetPage calculated a 0 based page index, but did not account
for the Bank 2 Page base.
Refer to Table 5 of RM0351 STM32L4x6 Reference Manual.